### PR TITLE
Make postcss build pluggable

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,5 +39,9 @@ module.exports = function tachyonsBuild (css, options) {
     plugins.push(classRepeat({ repeat: repeatNum }))
   }
 
+  if (options.plugins) {
+    plugins.push(...options.plugins)
+  }
+
   return postcss(plugins).process(css, options)
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "ava": "*",
+    "postcss-color-function": "^3.0.0",
     "standard": "^10.0.2",
     "tachyons-cli": "^1.0.9"
   }

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,8 @@ const input = fs.readFileSync('input.css', 'utf8')
 tachyonsBuildCss(input, {
   from: 'input.css',
   to: 'output.css',
-  minify: true
+  minify: true,
+  plugins: [my(), other(), plugins()]
 }).then(result => {
   fs.writeFileSync('output.css', result.css)
 })
@@ -34,6 +35,7 @@ tachyonsBuildCss(input, {
 | `to` | `undefined` | The output file name | file name |
 | `minify` | `false` | Minify the output CSS | `true`, `false` |
 | `repeat` | `false` | Whether to repeat classes in selectors | `false`, `1..10` |
+| `plugins` | `false` | Additional postcss plugins | [my(), other(), plugins()] |
 
 ## License
 

--- a/test/fixtures/input_color_function.css
+++ b/test/fixtures/input_color_function.css
@@ -1,0 +1,6 @@
+/*
+	POSTCSS COLOR FUNCTION
+*/
+body {
+	background: color(red a(90%));
+}

--- a/test/fixtures/output_color_function.css
+++ b/test/fixtures/output_color_function.css
@@ -1,0 +1,4 @@
+/*
+	POSTCSS COLOR FUNCTION
+*/
+body { background: rgba(255, 0, 0, 0.9); }

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import test from 'ava'
+import colorFunction from 'postcss-color-function'
 
 import tachyonsBuildCss from '../'
 
@@ -7,6 +8,8 @@ const input = fs.readFileSync('test/fixtures/input.css', 'utf8')
 const cssOutput = fs.readFileSync('test/fixtures/output.css', 'utf8')
 const cssMinOutput = fs.readFileSync('test/fixtures/output.min.css', 'utf8')
 const cssRepeatOutput = fs.readFileSync('test/fixtures/output.repeat.css', 'utf8')
+const inputColorFunction = fs.readFileSync('test/fixtures/input_color_function.css', 'utf8')
+const cssColorFunctionOutput = fs.readFileSync('test/fixtures/output_color_function.css', 'utf8')
 
 test.cb('processes source code', t => {
   testFixture(t, input, cssOutput)
@@ -18,6 +21,10 @@ test.cb('processes source code and minifies css', t => {
 
 test.cb('processes source code and repeats classes', t => {
   testFixture(t, input, cssRepeatOutput, { repeat: 4 })
+})
+
+test.cb('processes source code with custom plugins', t => {
+  testFixture(t, inputColorFunction, cssColorFunctionOutput, { plugins: [colorFunction()] })
 })
 
 function testFixture (t, input, output, opts) {


### PR DESCRIPTION
I was looking for a way to use some custom postcss plugins with the tachyons build process and ran across this [issue](https://github.com/tachyons-css/tachyons-build-css/issues/8) so I created a PR for it.

It extends the API (in a manner similar to as described in the issue), to accept an optional `plugins` option that would contain additional postcss plugins. 

Hopefully it's helpful. Thanks!
