### PR TITLE
added options for postcss-import

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,10 @@ module.exports = function tachyonsBuild (css, options) {
     trimTrailingZeros: false
   }
 
+  const atImportOptions = options.atImport || {}
+
   const plugins = [
-    atImport(), vars(), conditionals(), media(), queries(), perfect(perfectionistOptions), prefixer()
+    atImport(atImportOptions), vars(), conditionals(), media(), queries(), perfect(perfectionistOptions), prefixer()
   ]
 
   if (options.minify) {

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ tachyonsBuildCss(input, {
 | `minify` | `false` | Minify the output CSS | `true`, `false` |
 | `repeat` | `false` | Whether to repeat classes in selectors | `false`, `1..10` |
 | `plugins` | `false` | Additional postcss plugins | [my(), other(), plugins()] |
+| `atImport` | `{}` | Options for `postcss-import` | `postcss-import` options |
 
 ## License
 


### PR DESCRIPTION
So I can do this
https://github.com/des-des/tachyons-webpack-boilerplate/blob/master/lib/build.js#L14
ie
```js
tachyonsBuildCss(input, {
  atImport: {
    path: [
      path.join('node_modules', 'tachyons', 'src'),
      path.join(__dirname, 'app', 'css')
    ]
  },
  from: srcPath,
  to: destPath,
  minify: true,
  plugins: []
}).then(result => {
  fs.writeFileSync(destPath, result.css)
})
```

Giving the user control over to paths that postcss-import uses allows me to easily / elegantly extend tachyons

like this: https://github.com/des-des/tachyons-webpack-boilerplate/tree/master/app/css