### PR TITLE
added function that gets plugins used to build

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const conditionals = require('postcss-conditionals')
 const rmComments = require('postcss-discard-comments')
 const classRepeat = require('postcss-class-repeat')
 
-module.exports = function tachyonsBuild (css, options) {
+const getPlugins = function (options) {
   options = options || {}
 
   const perfectionistOptions = options.perfectionist || {
@@ -20,8 +20,10 @@ module.exports = function tachyonsBuild (css, options) {
     trimTrailingZeros: false
   }
 
+  const atImportOptions = options.atImport || {}
+
   const plugins = [
-    atImport(), vars(), conditionals(), media(), queries(), perfect(perfectionistOptions), prefixer()
+    atImport(atImportOptions), vars(), conditionals(), media(), queries(), perfect(perfectionistOptions), prefixer()
   ]
 
   if (options.minify) {
@@ -43,5 +45,13 @@ module.exports = function tachyonsBuild (css, options) {
     plugins.push(...options.plugins)
   }
 
+  return plugins
+}
+
+module.exports = function tachyonsBuild (css, options) {
+  const plugins = getPlugins(options)
+
   return postcss(plugins).process(css, options)
 }
+
+module.exports.getPlugins = getPlugins

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,17 @@ tachyonsBuildCss(input, {
 })
 ```
 
+If you want more control, but want the plugins used here, you can get them with the `getPlugins` function
+```javascript
+const { getPlugins } = require('tachyons-build-css')
+
+const plugins = getPlugins({
+  from: 'input.css',
+  to: 'output.css',
+  minify: true
+})
+```
+
 #### Options
 
 | Option | Default | Description | Values |

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 import test from 'ava'
 import colorFunction from 'postcss-color-function'
 
-import tachyonsBuildCss from '../'
+import tachyonsBuildCss, { getPlugins } from '../'
 
 const input = fs.readFileSync('test/fixtures/input.css', 'utf8')
 const cssOutput = fs.readFileSync('test/fixtures/output.css', 'utf8')
@@ -25,6 +25,15 @@ test.cb('processes source code and repeats classes', t => {
 
 test.cb('processes source code with custom plugins', t => {
   testFixture(t, inputColorFunction, cssColorFunctionOutput, { plugins: [colorFunction()] })
+})
+
+test.cb('getPlugins returns array of plugins', t => {
+  const plugins = getPlugins()
+
+  t.true(Array.isArray(plugins), 'returns an array')
+  t.true(plugins.every(plugin => typeof plugin === 'function'), 'all plugins are functions')
+
+  t.end()
 })
 
 function testFixture (t, input, output, opts) {


### PR DESCRIPTION
This allows me to use the plugins in my webpack config like [this](https://github.com/des-des/tachyons-webpack-boilerplate/blob/master/webpack_awaiting_pull.config.js#L37
).


Right now I can manually define the plugins like [this](https://github.com/des-des/tachyons-webpack-boilerplate/blob/master/postcss.config.js)

But I think it would be cleaner to just ask this module what plugins it uses.

Pros:
 * Gives the user more control of the plugins. Ie right now you can only append plugins. With this the user could remove a plugin, or prepend one.
 * allows the user to be certain they are using the correct plugins to build tachyons if they cannot use this module for some reason.

I can add tests if you want this functionality