### PR TITLE
Corrected repo link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "standard",
     "test": "ava -v"
   },
-  "repository": "johnotander/tachyons-build-css",
+  "repository": "tachyons-css/tachyons-build-css",
   "keywords": [],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
The current repo that is linked on https://www.npmjs.com/package/tachyons-build-css leads to a 404 so I've corrected the repo link in the package.json file. 